### PR TITLE
Switch complicated module if checks for simpler function

### DIFF
--- a/src/animations/attention-seekers/_bounce.scss
+++ b/src/animations/attention-seekers/_bounce.scss
@@ -19,7 +19,7 @@ $class-name: namespace($name-bounce);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce == true {
+@if useModule($enable-bounce) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce($prefix-webkit);

--- a/src/animations/attention-seekers/_flash.scss
+++ b/src/animations/attention-seekers/_flash.scss
@@ -1,7 +1,7 @@
 $keyframe-name: $name-flash;
 $class-name: namespace($name-flash);
 
-@if $enable-all-modules == true or $enable-flash == true {
+@if useModule($enable-flash) {
 
     @include animate-keyframe($keyframe-name) {
         0%, 50%, 100% {

--- a/src/animations/attention-seekers/_pulse.scss
+++ b/src/animations/attention-seekers/_pulse.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-pulse);
     }
 }
 
-@if $enable-all-modules == true or $enable-pulse == true {
+@if useModule($enable-pulse) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-pulse($prefix-webkit);

--- a/src/animations/attention-seekers/_rubber-band.scss
+++ b/src/animations/attention-seekers/_rubber-band.scss
@@ -25,7 +25,7 @@ $class-name: namespace($name-rubber-band);
     }
 }
 
-@if $enable-all-modules == true or $enable-rubber-band == true {
+@if useModule($enable-rubber-band) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rubber-band($prefix-webkit);

--- a/src/animations/attention-seekers/_shake.scss
+++ b/src/animations/attention-seekers/_shake.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-shake);
     }
 }
 
-@if $enable-all-modules == true or $enable-shake == true {
+@if useModule($enable-shake) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-shake($prefix-webkit);

--- a/src/animations/attention-seekers/_swing.scss
+++ b/src/animations/attention-seekers/_swing.scss
@@ -19,7 +19,7 @@ $class-name: namespace($name-swing);
     }
 }
 
-@if $enable-all-modules == true or $enable-swing == true {
+@if useModule($enable-swing) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-swing($prefix-webkit);

--- a/src/animations/attention-seekers/_tada.scss
+++ b/src/animations/attention-seekers/_tada.scss
@@ -19,7 +19,7 @@ $class-name: namespace($name-tada);
     }
 }
 
-@if $enable-all-modules == true or $enable-tada == true {
+@if useModule($enable-tada) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animation-tada($prefix-webkit);

--- a/src/animations/attention-seekers/_wobble.scss
+++ b/src/animations/attention-seekers/_wobble.scss
@@ -27,7 +27,7 @@ $class-name: namespace($name-wobble);
     }
 }
 
-@if $enable-all-modules == true or $enable-wobble == true {
+@if useModule($enable-wobble) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-wobble($prefix-webkit);

--- a/src/animations/bouncing-entrances/_bounce-in-down.scss
+++ b/src/animations/bouncing-entrances/_bounce-in-down.scss
@@ -24,7 +24,7 @@ $class-name: namespace($name-bounce-in-down);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-in-down == true {
+@if useModule($enable-bounce-in-down) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-in-down($prefix-webkit);

--- a/src/animations/bouncing-entrances/_bounce-in-left.scss
+++ b/src/animations/bouncing-entrances/_bounce-in-left.scss
@@ -24,7 +24,7 @@ $class-name: namespace($name-bounce-in-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-in-left == true {
+@if useModule($enable-bounce-in-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-in-left($prefix-webkit);

--- a/src/animations/bouncing-entrances/_bounce-in-right.scss
+++ b/src/animations/bouncing-entrances/_bounce-in-right.scss
@@ -29,7 +29,7 @@ $class-name: namespace($name-bounce-in-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-in-right == true {
+@if useModule($enable-bounce-in-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-in-right($prefix-webkit);

--- a/src/animations/bouncing-entrances/_bounce-in-up.scss
+++ b/src/animations/bouncing-entrances/_bounce-in-up.scss
@@ -29,7 +29,7 @@ $class-name: namespace($name-bounce-in-up);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-in-up == true {
+@if useModule($enable-bounce-in-up) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-in-up($prefix-webkit);

--- a/src/animations/bouncing-entrances/_bounce-in.scss
+++ b/src/animations/bouncing-entrances/_bounce-in.scss
@@ -28,7 +28,7 @@ $class-name: namespace($name-bounce-in);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-in == true {
+@if useModule($enable-bounce-in) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-in($prefix-webkit);

--- a/src/animations/bouncing-exits/_bounce-out-down.scss
+++ b/src/animations/bouncing-exits/_bounce-out-down.scss
@@ -17,7 +17,7 @@ $class-name: namespace($name-bounce-out-down);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-out-down == true {
+@if useModule($enable-bounce-out-down) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-out-down($prefix-webkit);

--- a/src/animations/bouncing-exits/_bounce-out-left.scss
+++ b/src/animations/bouncing-exits/_bounce-out-left.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-bounce-out-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-out-left == true {
+@if useModule($enable-bounce-out-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-out-left($prefix-webkit);

--- a/src/animations/bouncing-exits/_bounce-out-right.scss
+++ b/src/animations/bouncing-exits/_bounce-out-right.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-bounce-out-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-out-right == true {
+@if useModule($enable-bounce-out-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-out-right($prefix-webkit);

--- a/src/animations/bouncing-exits/_bounce-out-up.scss
+++ b/src/animations/bouncing-exits/_bounce-out-up.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-bounce-out-up);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-out-up == true {
+@if useModule($enable-bounce-out-up) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-out-up($prefix-webkit);

--- a/src/animations/bouncing-exits/_bounce-out.scss
+++ b/src/animations/bouncing-exits/_bounce-out.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-bounce-out);
     }
 }
 
-@if $enable-all-modules == true or $enable-bounce-out == true {
+@if useModule($enable-bounce-out) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-bounce-out($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-down-big.scss
+++ b/src/animations/fading-entrances/_fade-in-down-big.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-down-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-down-big == true {
+@if useModule($enable-fade-in-down-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-down-big($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-down.scss
+++ b/src/animations/fading-entrances/_fade-in-down.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-down);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-down == true {
+@if useModule($enable-fade-in-down) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-down($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-left-big.scss
+++ b/src/animations/fading-entrances/_fade-in-left-big.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-left-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-left-big == true {
+@if useModule($enable-fade-in-left-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-left-big($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-left.scss
+++ b/src/animations/fading-entrances/_fade-in-left.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-left == true {
+@if useModule($enable-fade-in-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-left($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-right-big.scss
+++ b/src/animations/fading-entrances/_fade-in-right-big.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-right-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-right-big == true {
+@if useModule($enable-fade-in-right-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-right-big($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-right.scss
+++ b/src/animations/fading-entrances/_fade-in-right.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-right == true {
+@if useModule($enable-fade-in-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-right($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-up-big.scss
+++ b/src/animations/fading-entrances/_fade-in-up-big.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-up-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-up-big == true {
+@if useModule($enable-fade-in-up-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-up-big($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in-up.scss
+++ b/src/animations/fading-entrances/_fade-in-up.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-fade-in-up);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-in-up == true {
+@if useModule($enable-fade-in-up) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-in-up($prefix-webkit);

--- a/src/animations/fading-entrances/_fade-in.scss
+++ b/src/animations/fading-entrances/_fade-in.scss
@@ -1,7 +1,7 @@
 $keyframe-name: $name-fade-in;
 $class-name: namespace($name-fade-in);
 
-@if $enable-all-modules == true or $enable-fade-in == true {
+@if useModule($enable-fade-in) {
 
     @include animate-keyframe($keyframe-name) {
         0% {

--- a/src/animations/fading-exits/_fade-out-down-big.scss
+++ b/src/animations/fading-exits/_fade-out-down-big.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-down-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-down-big == true {
+@if useModule($enable-fade-out-down-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-down-big($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out-down.scss
+++ b/src/animations/fading-exits/_fade-out-down.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-down);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-down == true {
+@if useModule($enable-fade-out-down) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-down($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out-left-big.scss
+++ b/src/animations/fading-exits/_fade-out-left-big.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-left-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-left-big == true {
+@if useModule($enable-fade-out-left-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-left-big($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out-left.scss
+++ b/src/animations/fading-exits/_fade-out-left.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-left == true {
+@if useModule($enable-fade-out-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-left($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out-right-big.scss
+++ b/src/animations/fading-exits/_fade-out-right-big.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-right-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-right-big == true {
+@if useModule($enable-fade-out-right-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-right-big($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out-right.scss
+++ b/src/animations/fading-exits/_fade-out-right.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-right == true {
+@if useModule($enable-fade-out-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-right($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out-up-big.scss
+++ b/src/animations/fading-exits/_fade-out-up-big.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-up-big);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-up-big == true {
+@if useModule($enable-fade-out-up-big) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-up-big($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out-up.scss
+++ b/src/animations/fading-exits/_fade-out-up.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-fade-out-up);
     }
 }
 
-@if $enable-all-modules == true or $enable-fade-out-up == true {
+@if useModule($enable-fade-out-up) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-fade-out-up($prefix-webkit);

--- a/src/animations/fading-exits/_fade-out.scss
+++ b/src/animations/fading-exits/_fade-out.scss
@@ -1,7 +1,7 @@
 $keyframe-name: $name-fade-out;
 $class-name: namespace($name-fade-out);
 
-@if $enable-all-modules == true or $enable-fade-out == true {
+@if useModule($enable-fade-out) {
 
     @include animate-keyframe($keyframe-name) {
         0% {

--- a/src/animations/flippers/_flip-in-x.scss
+++ b/src/animations/flippers/_flip-in-x.scss
@@ -27,7 +27,7 @@ $class-name: namespace($name-flip-in-x);
     }
 }
 
-@if $enable-all-modules == true or $enable-flip-in-x == true {
+@if useModule($enable-flip-in-x) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-flip-in-x($prefix-webkit);

--- a/src/animations/flippers/_flip-in-y.scss
+++ b/src/animations/flippers/_flip-in-y.scss
@@ -27,7 +27,7 @@ $class-name: namespace($name-flip-in-y);
     }
 }
 
-@if $enable-all-modules == true or $enable-flip-in-y == true {
+@if useModule($enable-flip-in-y) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-flip-in-y($prefix-webkit);

--- a/src/animations/flippers/_flip-out-x.scss
+++ b/src/animations/flippers/_flip-out-x.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-flip-out-x);
     }
 }
 
-@if $enable-all-modules == true or $enable-flip-out-x == true {
+@if useModule($enable-flip-out-x) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-flip-out-x($prefix-webkit);

--- a/src/animations/flippers/_flip-out-y.scss
+++ b/src/animations/flippers/_flip-out-y.scss
@@ -17,7 +17,7 @@ $class-name: namespace($name-flip-out-y);
     }
 }
 
-@if $enable-all-modules == true or $enable-flip-out-y == true {
+@if useModule($enable-flip-out-y) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-flip-out-y($prefix-webkit);

--- a/src/animations/flippers/_flip.scss
+++ b/src/animations/flippers/_flip.scss
@@ -28,7 +28,7 @@ $class-name: namespace($name-flip);
     }
 }
 
-@if $enable-all-modules == true or $enable-flip == true {
+@if useModule($enable-flip) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-flip($prefix-webkit);

--- a/src/animations/lightspeed/_lightspeed-in.scss
+++ b/src/animations/lightspeed/_lightspeed-in.scss
@@ -23,7 +23,7 @@ $class-name: namespace($name-lightspeed-in);
     }
 }
 
-@if $enable-all-modules == true or $enable-lightspeed-in == true {
+@if useModule($enable-lightspeed-in) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-lightspeed-in($prefix-webkit);

--- a/src/animations/lightspeed/_lightspeed-out.scss
+++ b/src/animations/lightspeed/_lightspeed-out.scss
@@ -12,7 +12,7 @@ $class-name: namespace($name-lightspeed-out);
     }
 }
 
-@if $enable-all-modules == true or $enable-lightspeed-out == true {
+@if useModule($enable-lightspeed-out) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-lightspeed-out($prefix-webkit);

--- a/src/animations/rotating-entrances/_rotate-in-down-left.scss
+++ b/src/animations/rotating-entrances/_rotate-in-down-left.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-rotate-in-down-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-in-down-left == true {
+@if useModule($enable-rotate-in-down-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-in-down-left($prefix-webkit);

--- a/src/animations/rotating-entrances/_rotate-in-down-right.scss
+++ b/src/animations/rotating-entrances/_rotate-in-down-right.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-rotate-in-down-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-in-down-right == true {
+@if useModule($enable-rotate-in-down-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-in-down-right($prefix-webkit);

--- a/src/animations/rotating-entrances/_rotate-in-up-left.scss
+++ b/src/animations/rotating-entrances/_rotate-in-up-left.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-rotate-in-up-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-in-up-left == true {
+@if useModule($enable-rotate-in-up-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-in-up-left($prefix-webkit);

--- a/src/animations/rotating-entrances/_rotate-in-up-right.scss
+++ b/src/animations/rotating-entrances/_rotate-in-up-right.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-rotate-in-up-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-in-up-right == true {
+@if useModule($enable-rotate-in-up-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-in-up-right($prefix-webkit);

--- a/src/animations/rotating-entrances/_rotate-in.scss
+++ b/src/animations/rotating-entrances/_rotate-in.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-rotate-in);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-in == true {
+@if useModule($enable-rotate-in) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-in($prefix-webkit);

--- a/src/animations/rotating-exits/_rotate-out-down-left.scss
+++ b/src/animations/rotating-exits/_rotate-out-down-left.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-rotate-out-down-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-out-down-left == true {
+@if useModule($enable-rotate-out-down-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-out-down-left($prefix-webkit);

--- a/src/animations/rotating-exits/_rotate-out-down-right.scss
+++ b/src/animations/rotating-exits/_rotate-out-down-right.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-rotate-out-down-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-out-down-right == true {
+@if useModule($enable-rotate-out-down-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-out-down-right($prefix-webkit);

--- a/src/animations/rotating-exits/_rotate-out-up-left.scss
+++ b/src/animations/rotating-exits/_rotate-out-up-left.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-rotate-out-up-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-out-up-left == true {
+@if useModule($enable-rotate-out-up-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-out-up-left($prefix-webkit);

--- a/src/animations/rotating-exits/_rotate-out-up-right.scss
+++ b/src/animations/rotating-exits/_rotate-out-up-right.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-rotate-out-up-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-out-up-right == true {
+@if useModule($enable-rotate-out-up-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-out-up-right($prefix-webkit);

--- a/src/animations/rotating-exits/_rotate-out.scss
+++ b/src/animations/rotating-exits/_rotate-out.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-rotate-out);
     }
 }
 
-@if $enable-all-modules == true or $enable-rotate-out == true {
+@if useModule($enable-rotate-out) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-rotate-out($prefix-webkit);

--- a/src/animations/special/_hinge.scss
+++ b/src/animations/special/_hinge.scss
@@ -23,7 +23,7 @@ $class-name: namespace($name-hinge);
     }
 }
 
-@if $enable-all-modules == true or $enable-hinge == true {
+@if useModule($enable-hinge) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-hinge($prefix-webkit);

--- a/src/animations/special/_roll-in.scss
+++ b/src/animations/special/_roll-in.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-roll-in);
     }
 }
 
-@if $enable-all-modules == true or $enable-roll-in == true {
+@if useModule($enable-roll-in) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-roll-in($prefix-webkit);

--- a/src/animations/special/_roll-out.scss
+++ b/src/animations/special/_roll-out.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-roll-out);
     }
 }
 
-@if $enable-all-modules == true or $enable-roll-out == true {
+@if useModule($enable-roll-out) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-roll-out($prefix-webkit);

--- a/src/animations/zooming-entrances/_zoom-in-down.scss
+++ b/src/animations/zooming-entrances/_zoom-in-down.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-zoom-in-down);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-in-down == true {
+@if useModule($enable-zoom-in-down) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-in-down($prefix-webkit);

--- a/src/animations/zooming-entrances/_zoom-in-left.scss
+++ b/src/animations/zooming-entrances/_zoom-in-left.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-zoom-in-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-in-left == true {
+@if useModule($enable-zoom-in-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-in-left($prefix-webkit);

--- a/src/animations/zooming-entrances/_zoom-in-right.scss
+++ b/src/animations/zooming-entrances/_zoom-in-right.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-zoom-in-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-in-right == true {
+@if useModule($enable-zoom-in-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-in-right($prefix-webkit);

--- a/src/animations/zooming-entrances/_zoom-in-up.scss
+++ b/src/animations/zooming-entrances/_zoom-in-up.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-zoom-in-up);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-in-up == true {
+@if useModule($enable-zoom-in-up) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-in-up($prefix-webkit);

--- a/src/animations/zooming-entrances/_zoom-in.scss
+++ b/src/animations/zooming-entrances/_zoom-in.scss
@@ -11,7 +11,7 @@ $class-name: namespace($name-zoom-in);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-in == true {
+@if useModule($enable-zoom-in) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-in($prefix-webkit);

--- a/src/animations/zooming-exits/_zoom-out-down.scss
+++ b/src/animations/zooming-exits/_zoom-out-down.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-zoom-out-down);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-out-down == true {
+@if useModule($enable-zoom-out-down) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-out-down($prefix-webkit);

--- a/src/animations/zooming-exits/_zoom-out-left.scss
+++ b/src/animations/zooming-exits/_zoom-out-left.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-zoom-out-left);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-out-left == true {
+@if useModule($enable-zoom-out-left) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-out-left($prefix-webkit);

--- a/src/animations/zooming-exits/_zoom-out-right.scss
+++ b/src/animations/zooming-exits/_zoom-out-right.scss
@@ -13,7 +13,7 @@ $class-name: namespace($name-zoom-out-right);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-out-right == true {
+@if useModule($enable-zoom-out-right) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-out-right($prefix-webkit);

--- a/src/animations/zooming-exits/_zoom-out-up.scss
+++ b/src/animations/zooming-exits/_zoom-out-up.scss
@@ -15,7 +15,7 @@ $class-name: namespace($name-zoom-out-up);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-out-up == true {
+@if useModule($enable-zoom-out-up) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-out-up($prefix-webkit);

--- a/src/animations/zooming-exits/_zoom-out.scss
+++ b/src/animations/zooming-exits/_zoom-out.scss
@@ -14,7 +14,7 @@ $class-name: namespace($name-zoom-out);
     }
 }
 
-@if $enable-all-modules == true or $enable-zoom-out == true {
+@if useModule($enable-zoom-out) {
     @if $enable-prefixes == true {
         @-webkit-keyframes #{$keyframe-name} {
             @include animate-zoom-out($prefix-webkit);

--- a/src/utilities/_base-classes.scss
+++ b/src/utilities/_base-classes.scss
@@ -22,14 +22,16 @@
     animation-iteration-count: infinite;
 }
 
-.#{$name-base}.#{$name-hinge} {
-    $hinge-duration: $default-animation-duration * 2;
+@if useModule($enable-hinge) {
+    .#{$name-base}.#{$name-hinge} {
+        $hinge-duration: $default-animation-duration * 2;
 
-    @if $enable-prefixes == true {
-        -webkit-animation-duration: $hinge-duration;
-        -moz-animation-duration: $hinge-duration;
-        -o-animation-duration: $hinge-duration;
+        @if $enable-prefixes == true {
+            -webkit-animation-duration: $hinge-duration;
+            -moz-animation-duration: $hinge-duration;
+            -o-animation-duration: $hinge-duration;
+        }
+
+        animation-duration: $hinge-duration;
     }
-
-    animation-duration: $hinge-duration;
 }

--- a/src/utilities/_functions.scss
+++ b/src/utilities/_functions.scss
@@ -8,3 +8,14 @@
 @function namespace($name) {
     @return $name-prefix + $name;
 }
+
+
+
+// Check for enabled animation modules
+@function useModule($module, $all: $enable-all-modules) {
+    @if ($all == true or $module == true) {
+        @return true;
+    }
+
+    @return false;
+}


### PR DESCRIPTION
Removes repeated `$enable-all-modules` check from every module out into a single function.
