### PR TITLE
Add example of enabling vendor prefixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Autoprefixer to handle prefixing.
 When enabled, all necessary CSS declarations include vendor prefixes for Webkit,
 Mozilla, and Opera browsers.
 
+##### Enable Vendor Prefixes
+```scss
+$enable-prefixes: true;
+```
+
 
 #### Class Naming
 


### PR DESCRIPTION
It took me a few minutes to figure that the vendor prefixes weren't being added to the processed CSS. I had to look for the variable name in the code, so I added it to the README for the next developer.